### PR TITLE
[LMS-15292] Upgrade jstastny/publish-gem-to-github to latest version

### DIFF
--- a/.github/workflows/publish-on-push.yaml
+++ b/.github/workflows/publish-on-push.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build and publish gem
-      uses: jstastny/publish-gem-to-github@v1.0
+      uses: jstastny/publish-gem-to-github@v2.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         owner: acima-credit

--- a/field_struct.gemspec
+++ b/field_struct.gemspec
@@ -10,11 +10,16 @@ Gem::Specification.new do |spec|
   spec.email = ['adrian.madrid@acimacredit.com']
   
   current_branch = `git branch --remote --contains | sed "s|[[:space:]]*origin/||"`.strip
-  branch_commit = `git rev-parse HEAD`.strip[0..6]
+
+  raise 'Could not determine current branch' if current_branch.empty?
 
   if current_branch == 'master'
     spec.version = FieldStruct::VERSION
   else
+    branch_commit = `git rev-parse HEAD`.strip[0..6]
+
+    raise 'Could not determine current commit SHA' if branch_commit.empty?
+
     spec.version = "#{FieldStruct::VERSION}-#{branch_commit}"
   end
 


### PR DESCRIPTION
## Jira Ticket
https://acima.atlassian.net/browse/LMS-15292

We are unable to build gems for PR's with current github packages push action:
```
Invalid gemspec in [field_struct.gemspec]: Malformed version number string 0.2.26-
ERROR:  Error loading gemspec. Aborting.
Pushing the built gem to GitHub Package Registry
ERROR:  While executing gem ... (Gem::Package::FormatError)
    No such file or directory @ rb_sysopen - *.gem
```
The root cause of this comes from https://github.com/jstastny/publish-gem-to-github/issues/8 issue.




