### PR TITLE
Add avro method to Metadata

### DIFF
--- a/field_struct.gemspec
+++ b/field_struct.gemspec
@@ -46,7 +46,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'digest-crc'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'

--- a/field_struct.gemspec
+++ b/field_struct.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'digest-crc'
 
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'

--- a/lib/field_struct/structs/metadata.rb
+++ b/lib/field_struct/structs/metadata.rb
@@ -64,7 +64,7 @@ module FieldStruct
       include Comparable
 
       ATTRIBUTE_NAMES = %i[
-        type of version required default format enum min_length max_length description array range alias
+        type of version required default format enum min_length max_length description array range alias avro
       ].freeze
       ATTRIBUTE_METH_RX = /\A(#{ATTRIBUTE_NAMES.map(&:to_s).join('|')})(\?|=)?\z/.freeze
 
@@ -102,6 +102,11 @@ module FieldStruct
 
       def optional?
         !required?
+      end
+
+      def avro=(value)
+        raise "Value must be a Hash" unless value.is_a?(Hash)
+        set :avro, value
       end
 
       delegate :inspect, :to_s, :keys, :delete, to: :@values
@@ -307,7 +312,7 @@ module FieldStruct
     def reset_version
       @version = build_version attributes: {
         attribute: {
-          only_keys: %i[type of required default format enum min_length max_length]
+          only_keys: %i[type of required default format enum min_length max_length avro]
         }
       }
     end

--- a/lib/field_struct/structs/metadata.rb
+++ b/lib/field_struct/structs/metadata.rb
@@ -16,7 +16,7 @@ module FieldStruct
         make_class(metadata, root).tap do |klass|
           metadata.attributes.each do |name, options|
             type = options.delete :type
-            klass.attribute name, type, options
+            klass.attribute name, type, **options
           end
         end
       end
@@ -102,12 +102,6 @@ module FieldStruct
 
       def optional?
         !required?
-      end
-
-      def avro=(value)
-        raise 'Value must be a Hash' unless value.is_a?(Hash)
-
-        set :avro, value
       end
 
       delegate :inspect, :to_s, :keys, :delete, to: :@values

--- a/lib/field_struct/structs/metadata.rb
+++ b/lib/field_struct/structs/metadata.rb
@@ -105,7 +105,8 @@ module FieldStruct
       end
 
       def avro=(value)
-        raise "Value must be a Hash" unless value.is_a?(Hash)
+        raise 'Value must be a Hash' unless value.is_a?(Hash)
+
         set :avro, value
       end
 

--- a/lib/field_struct/version.rb
+++ b/lib/field_struct/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FieldStruct
-  VERSION = '0.2.26'
+  VERSION = '0.2.27'
 end

--- a/spec/structs/flexible_spec.rb
+++ b/spec/structs/flexible_spec.rb
@@ -13,6 +13,7 @@ module FieldStruct
       required :level, :integer, default: -> { 2 }
       optional :at, :time
       optional :active, :boolean, default: false
+      required :department, :string, avro: { field_id: "user_dept" }
     end
 
     class Person < FieldStruct.flexible
@@ -60,7 +61,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
       it { expect(subject.name).to eq 'FieldStruct::FlexibleExamples::User' }
       it { expect(subject.schema_name).to eq 'field_struct.flexible_examples.user' }
       it { expect(subject.type).to eq :flexible }
-      it { expect(subject.version).to eq '245178bc' }
+      it { expect(subject.version).to eq 'f8a28d00' }
       it 'full hash' do
         expect(subject.to_hash).to eq name: 'FieldStruct::FlexibleExamples::User',
                                       schema_name: 'field_struct.flexible_examples.user',
@@ -81,9 +82,10 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
                                         source: { type: :string, required: true, enum: %w[A B C] },
                                         level: { type: :integer, required: true, default: '<proc>' },
                                         at: { type: :time },
-                                        active: { type: :boolean, default: false }
+                                        active: { type: :boolean, default: false },
+                                        department: { type: :string, required: true, avro: { field_id: "user_dept" }}
                                       },
-                                      version: '245178bc'
+                                      version: 'f8a28d00'
       end
       it 'filtered hash' do
         options = { attributes: { attribute: { only_keys: %i[type of required default enum] } } }
@@ -97,9 +99,10 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
                                                  source: { type: :string, required: true, enum: %w[A B C] },
                                                  level: { type: :integer, required: true, default: '<proc>' },
                                                  at: { type: :time },
-                                                 active: { type: :boolean, default: false }
+                                                 active: { type: :boolean, default: false },
+                                                 department: { type: :string, required: true }
                                                },
-                                               version: '245178bc'
+                                               version: 'f8a28d00'
       end
       context 'to_hash' do
         let(:exp_hash) do
@@ -114,9 +117,10 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
               source: { type: :string, required: true, enum: %w[A B C] },
               level: { type: :integer, required: true, default: '<proc>' },
               at: { type: :time },
-              active: { type: :boolean, default: false }
+              active: { type: :boolean, default: false },
+              department: { type: :string, required: true, avro: { field_id: "user_dept" }}
             },
-            version: '245178bc'
+            version: 'f8a28d00'
           }
         end
         it { expect(subject.to_hash).to eq exp_hash }
@@ -125,7 +129,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
     context '.attribute_types' do
       subject { described_class.attribute_types }
       it { expect(subject).to be_a Hash }
-      it { expect(subject.keys).to eq %w[username password age owed source level at active] }
+      it { expect(subject.keys).to eq %w[username password age owed source level at active department] }
       it { expect(subject['username']).to be_a ActiveModel::Type::String }
       it { expect(subject['password']).to be_a ActiveModel::Type::String }
       it { expect(subject['age']).to be_a ActiveModel::Type::Integer }
@@ -134,6 +138,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
       it { expect(subject['level']).to be_a ActiveModel::Type::Integer }
       it { expect(subject['at']).to be_a ActiveModel::Type::Time }
       it { expect(subject['active']).to be_a ActiveModel::Type::Boolean }
+      it { expect(subject['department']). to be_a ActiveModel::Type::String }
     end
   end
   describe 'instance' do
@@ -145,6 +150,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
     let(:level) { 3 }
     let(:at) { Time.parse('2018-03-24') }
     let(:active) { true }
+    let(:department) { 'some_department' }
     let(:full_params) do
       basic_hash username: username,
                  password: password,
@@ -153,7 +159,8 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
                  source: source,
                  level: level,
                  at: at,
-                 active: active
+                 active: active,
+                 department: department
     end
     subject { described_class.new params }
     context 'full' do
@@ -169,6 +176,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
         it { expect(subject.at).to eq Time.parse('2018-03-24') }
         it { expect(subject.active).to eq true }
         it { expect(subject.extras).to eq({}) }
+        it { expect(subject.department).to eq 'some_department' }
       end
       context 'immutability' do
         let(:error_msg) { "can't modify frozen attributes" }
@@ -180,6 +188,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
         it { expect { subject.level = 'x' }.to raise_error FrozenError, error_msg }
         it { expect { subject.at = 'x' }.to raise_error FrozenError, error_msg }
         it { expect { subject.active = 'x' }.to raise_error FrozenError, error_msg }
+        it { expect { subject.department = 'x'}.to raise_error FrozenError, error_msg }
       end
     end
     context 'full + extras' do
@@ -201,6 +210,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
       it { expect(subject.level).to eq 2 }
       it { expect(subject.at).to eq nil }
       it { expect(subject.active).to eq false }
+      it { expect(subject.department).to eq 'some_department' }
       it { expect(subject.errors).to be_a ActiveModel::Errors }
       it { expect(subject.errors.to_hash).to eq errors }
       it { expect(subject.errors.full_messages).to eq messages }

--- a/spec/structs/flexible_spec.rb
+++ b/spec/structs/flexible_spec.rb
@@ -13,7 +13,7 @@ module FieldStruct
       required :level, :integer, default: -> { 2 }
       optional :at, :time
       optional :active, :boolean, default: false
-      required :department, :string, avro: { field_id: "user_dept" }
+      required :department, :string, avro: { field_id: 'user_dept' }
     end
 
     class Person < FieldStruct.flexible
@@ -83,7 +83,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
                                         level: { type: :integer, required: true, default: '<proc>' },
                                         at: { type: :time },
                                         active: { type: :boolean, default: false },
-                                        department: { type: :string, required: true, avro: { field_id: "user_dept" }}
+                                        department: { type: :string, required: true, avro: { field_id: 'user_dept' } }
                                       },
                                       version: 'f8a28d00'
       end
@@ -118,7 +118,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
               level: { type: :integer, required: true, default: '<proc>' },
               at: { type: :time },
               active: { type: :boolean, default: false },
-              department: { type: :string, required: true, avro: { field_id: "user_dept" }}
+              department: { type: :string, required: true, avro: { field_id: 'user_dept' } }
             },
             version: 'f8a28d00'
           }
@@ -138,7 +138,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
       it { expect(subject['level']).to be_a ActiveModel::Type::Integer }
       it { expect(subject['at']).to be_a ActiveModel::Type::Time }
       it { expect(subject['active']).to be_a ActiveModel::Type::Boolean }
-      it { expect(subject['department']). to be_a ActiveModel::Type::String }
+      it { expect(subject['department']).to be_a ActiveModel::Type::String }
     end
   end
   describe 'instance' do
@@ -188,7 +188,7 @@ RSpec.describe FieldStruct::FlexibleExamples::User do
         it { expect { subject.level = 'x' }.to raise_error FrozenError, error_msg }
         it { expect { subject.at = 'x' }.to raise_error FrozenError, error_msg }
         it { expect { subject.active = 'x' }.to raise_error FrozenError, error_msg }
-        it { expect { subject.department = 'x'}.to raise_error FrozenError, error_msg }
+        it { expect { subject.department = 'x' }.to raise_error FrozenError, error_msg }
       end
     end
     context 'full + extras' do

--- a/spec/structs/mutable_spec.rb
+++ b/spec/structs/mutable_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe FieldStruct::MutableExamples::User do
       it { expect(subject[:level]).to eq type: :integer, required: true, default: '<proc>' }
       it { expect(subject[:at]).to eq type: :time }
       it { expect(subject[:active]).to eq type: :boolean, default: false }
-      it { expect(subject[:department]).to eq type: :string, required: true, avro: { field_id: 'user_dept' }}
+      it { expect(subject[:department]).to eq type: :string, required: true, avro: { field_id: 'user_dept' } }
     end
     context '.attribute_types' do
       subject { described_class.attribute_types }

--- a/spec/structs/mutable_spec.rb
+++ b/spec/structs/mutable_spec.rb
@@ -13,6 +13,7 @@ module FieldStruct
       required :level, :integer, default: -> { 2 }
       optional :at, :time
       optional :active, :boolean, default: false
+      required :department, :string, avro: { field_id: 'user_dept' }
     end
 
     class Person < FieldStruct.mutable
@@ -57,8 +58,8 @@ RSpec.describe FieldStruct::MutableExamples::User do
       it { expect(subject.name).to eq 'FieldStruct::MutableExamples::User' }
       it { expect(subject.schema_name).to eq 'field_struct.mutable_examples.user' }
       it { expect(subject.type).to eq :mutable }
-      it { expect(subject.version).to eq '8c79b75b' }
-      it { expect(subject.keys).to eq %i[username password age owed source level at active] }
+      it { expect(subject.version).to eq 'a30acd0f' }
+      it { expect(subject.keys).to eq %i[username password age owed source level at active department] }
       it { expect(subject[:username]).to eq type: :string, required: true, format: /\A[a-z]/i }
       it { expect(subject[:password]).to eq type: :string }
       it { expect(subject[:age]).to eq type: :integer, required: true }
@@ -67,11 +68,12 @@ RSpec.describe FieldStruct::MutableExamples::User do
       it { expect(subject[:level]).to eq type: :integer, required: true, default: '<proc>' }
       it { expect(subject[:at]).to eq type: :time }
       it { expect(subject[:active]).to eq type: :boolean, default: false }
+      it { expect(subject[:department]).to eq type: :string, required: true, avro: { field_id: 'user_dept' }}
     end
     context '.attribute_types' do
       subject { described_class.attribute_types }
       it { expect(subject).to be_a Hash }
-      it { expect(subject.keys).to eq %w[username password age owed source level at active] }
+      it { expect(subject.keys).to eq %w[username password age owed source level at active department] }
       it { expect(subject['username']).to be_a ActiveModel::Type::String }
       it { expect(subject['password']).to be_a ActiveModel::Type::String }
       it { expect(subject['age']).to be_a ActiveModel::Type::Integer }
@@ -80,6 +82,7 @@ RSpec.describe FieldStruct::MutableExamples::User do
       it { expect(subject['level']).to be_a ActiveModel::Type::Integer }
       it { expect(subject['at']).to be_a ActiveModel::Type::Time }
       it { expect(subject['active']).to be_a ActiveModel::Type::Boolean }
+      it { expect(subject['department']).to be_a ActiveModel::Type::String }
     end
   end
   describe 'instance' do
@@ -91,6 +94,7 @@ RSpec.describe FieldStruct::MutableExamples::User do
     let(:level) { 3 }
     let(:at) { Time.parse('2018-03-24') }
     let(:active) { true }
+    let(:department) { 'some_department' }
     let(:full_params) do
       basic_hash username: username,
                  password: password,
@@ -99,7 +103,8 @@ RSpec.describe FieldStruct::MutableExamples::User do
                  source: source,
                  level: level,
                  at: at,
-                 active: active
+                 active: active,
+                 department: department
     end
     subject { described_class.new params }
     context 'full' do
@@ -114,6 +119,7 @@ RSpec.describe FieldStruct::MutableExamples::User do
         it { expect(subject.level).to eq 3 }
         it { expect(subject.at).to eq Time.parse('2018-03-24') }
         it { expect(subject.active).to eq true }
+        it { expect(subject.department).to eq 'some_department' }
       end
       context 'immutability' do
         it do
@@ -147,6 +153,10 @@ RSpec.describe FieldStruct::MutableExamples::User do
         it do
           expect { subject.active = true }.to_not raise_error
           expect(subject.active).to eq true
+        end
+        it do
+          expect { subject.department = 'x' }.to_not raise_error
+          expect(subject.department).to eq 'x'
         end
       end
       context 'coercion' do
@@ -249,6 +259,7 @@ RSpec.describe FieldStruct::MutableExamples::User do
       it { expect(subject.level).to eq 2 }
       it { expect(subject.at).to eq nil }
       it { expect(subject.active).to eq false }
+      it { expect(subject.department).to eq 'some_department' }
       it { expect(subject.errors).to be_a ActiveModel::Errors }
       it { expect(subject.errors.to_hash).to eq errors }
       it { expect(subject.errors.full_messages).to eq messages }

--- a/spec/structs/strict_spec.rb
+++ b/spec/structs/strict_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe FieldStruct::StrictExamples::User do
       it { expect(subject[:level]).to eq type: :integer, required: true, default: '<proc>' }
       it { expect(subject[:at]).to eq type: :time }
       it { expect(subject[:active]).to eq type: :boolean, default: false }
-      it { expect(subject[:department]).to eq type: :string, required: true, avro: { field_id: 'user_dept' }}
+      it { expect(subject[:department]).to eq type: :string, required: true, avro: { field_id: 'user_dept' } }
     end
     context '.attribute_types' do
       subject { described_class.attribute_types }

--- a/spec/structs/strict_spec.rb
+++ b/spec/structs/strict_spec.rb
@@ -13,6 +13,7 @@ module FieldStruct
       required :level, :integer, default: -> { 2 }
       optional :at, :time
       optional :active, :boolean, default: false
+      required :department, :string, avro: { field_id: 'user_dept' }
     end
 
     class Person < FieldStruct.strict
@@ -55,8 +56,8 @@ RSpec.describe FieldStruct::StrictExamples::User do
       it { expect(subject.name).to eq 'FieldStruct::StrictExamples::User' }
       it { expect(subject.schema_name).to eq 'field_struct.strict_examples.user' }
       it { expect(subject.type).to eq :strict }
-      it { expect(subject.version).to eq '7d1bd1cb' }
-      it { expect(subject.keys).to eq %i[username password age owed source level at active] }
+      it { expect(subject.version).to eq '8fd7c2bf' }
+      it { expect(subject.keys).to eq %i[username password age owed source level at active department] }
       it { expect(subject[:username]).to eq type: :string, required: true, format: /\A[a-z]/i }
       it { expect(subject[:password]).to eq type: :string }
       it { expect(subject[:age]).to eq type: :integer, required: true }
@@ -65,11 +66,12 @@ RSpec.describe FieldStruct::StrictExamples::User do
       it { expect(subject[:level]).to eq type: :integer, required: true, default: '<proc>' }
       it { expect(subject[:at]).to eq type: :time }
       it { expect(subject[:active]).to eq type: :boolean, default: false }
+      it { expect(subject[:department]).to eq type: :string, required: true, avro: { field_id: 'user_dept' }}
     end
     context '.attribute_types' do
       subject { described_class.attribute_types }
       it { expect(subject).to be_a Hash }
-      it { expect(subject.keys).to eq %w[username password age owed source level at active] }
+      it { expect(subject.keys).to eq %w[username password age owed source level at active department] }
       it { expect(subject['username']).to be_a ActiveModel::Type::String }
       it { expect(subject['password']).to be_a ActiveModel::Type::String }
       it { expect(subject['age']).to be_a ActiveModel::Type::Integer }
@@ -78,6 +80,7 @@ RSpec.describe FieldStruct::StrictExamples::User do
       it { expect(subject['level']).to be_a ActiveModel::Type::Integer }
       it { expect(subject['at']).to be_a ActiveModel::Type::Time }
       it { expect(subject['active']).to be_a ActiveModel::Type::Boolean }
+      it { expect(subject['department']).to be_a ActiveModel::Type::String }
     end
   end
   describe 'instance' do
@@ -89,6 +92,7 @@ RSpec.describe FieldStruct::StrictExamples::User do
     let(:level) { 3 }
     let(:at) { Time.parse('2018-03-24') }
     let(:active) { true }
+    let(:department) { 'some_dept' }
     let(:full_params) do
       basic_hash username: username,
                  password: password,
@@ -97,7 +101,8 @@ RSpec.describe FieldStruct::StrictExamples::User do
                  source: source,
                  level: level,
                  at: at,
-                 active: active
+                 active: active,
+                 department: department
     end
     subject { described_class.new params }
     context 'full' do
@@ -112,6 +117,7 @@ RSpec.describe FieldStruct::StrictExamples::User do
         it { expect(subject.level).to eq 3 }
         it { expect(subject.at).to eq Time.parse('2018-03-24') }
         it { expect(subject.active).to eq true }
+        it { expect(subject.department).to eq 'some_dept' }
       end
       context 'immutability' do
         let(:error_msg) { "can't modify frozen attributes" }
@@ -123,6 +129,7 @@ RSpec.describe FieldStruct::StrictExamples::User do
         it { expect { subject.level = 'x' }.to raise_error FrozenError, error_msg }
         it { expect { subject.at = 'x' }.to raise_error FrozenError, error_msg }
         it { expect { subject.active = 'x' }.to raise_error FrozenError, error_msg }
+        it { expect { subject.department = 'x' }.to raise_error FrozenError, error_msg }
       end
     end
     context 'partial' do


### PR DESCRIPTION
This PR
- Adds `avro` to the list of possible `Attribute` names
- field_struct_avro_schema [will](https://github.com/acima-credit/field_struct_avro_schema/pull/20) read metadata out of this attribute to do things like match up sensitive data fields with a KMS key (via [avro_acima](https://github.com/acima-credit/avro-acima))
- Changes the call to `AttributeMethods#attribute` in metadata.rb:19 to spread the options hash into kwargs for ruby 3 compat