### PR TITLE
Update Ruby Pkg Publisher

### DIFF
--- a/.github/workflows/publish-on-push.yaml
+++ b/.github/workflows/publish-on-push.yaml
@@ -1,17 +1,15 @@
-name: Publish Ruby Gem To GitHub Packages (Pushed)
+name: Publish Ruby Gem (Pushed)
 
 on:
   push
 
 jobs:
-  build-and-push:
-    name: Build And Push Gems
-    uses: upbound-group/ruby-actions/.github/workflows/reusable_push_gems.yml@main  # locking to `main` branch for latest updates for now
-    secrets: inherit
-    permissions:
-      contents: read
-      packages: write
-    with:
-      registry-url: "https://rubygems.pkg.github.com/acima-credit"
-      use-github-token-as-bearer-token: true
-
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and publish gem
+        uses: jstastny/publish-gem-to-github@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: acima-credit

--- a/.github/workflows/publish-on-push.yaml
+++ b/.github/workflows/publish-on-push.yaml
@@ -1,16 +1,17 @@
-name: Publish Ruby Gem (Pushed)
+name: Publish Ruby Gem To GitHub Packages (Pushed)
 
 on:
   push
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Build and publish gem
-      uses: jstastny/publish-gem-to-github@v2.3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        owner: acima-credit
+  build-and-push:
+    name: Build And Push Gems
+    uses: upbound-group/ruby-actions/.github/workflows/reusable_push_gems.yml@main  # locking to `main` branch for latest updates for now
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+    with:
+      registry-url: "https://rubygems.pkg.github.com/acima-credit"
+      use-github-token-as-bearer-token: true
 

--- a/lib/field_struct/version.rb
+++ b/lib/field_struct/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FieldStruct
-  VERSION = '0.2.27'
+  VERSION = '0.2.28'
 end


### PR DESCRIPTION
## [FF-3981](https://acima.atlassian.net/browse/FF-3981)

There was an issue with Ruby Packages failing a little while back.  This updates the workflow to use the new credentials for publishing Ruby Packages.

## TESTING
It publishing the Package is the Test.

[FF-3981]: https://acima.atlassian.net/browse/FF-3981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ