### PR TITLE
Add Rails 8 Support

### DIFF
--- a/lib/field_struct/structs/flexible.rb
+++ b/lib/field_struct/structs/flexible.rb
@@ -11,6 +11,10 @@ module FieldStruct
       def field_struct_type
         :flexible
       end
+
+      def mutable?
+        false
+      end
     end
 
     # @param [Hash] attributes

--- a/lib/field_struct/structs/mutable.rb
+++ b/lib/field_struct/structs/mutable.rb
@@ -20,6 +20,10 @@ module FieldStruct
       after_attributes_initialize attributes
       validate
     end
+
+    def self.mutable?
+      true
+    end
   end
 
   # @return [Class]

--- a/lib/field_struct/structs/mutable.rb
+++ b/lib/field_struct/structs/mutable.rb
@@ -11,6 +11,10 @@ module FieldStruct
       def field_struct_type
         :mutable
       end
+
+      def mutable?
+        true
+      end
     end
 
     # @param [Hash] attributes
@@ -19,10 +23,6 @@ module FieldStruct
       super(attributes)
       after_attributes_initialize attributes
       validate
-    end
-
-    def self.mutable?
-      true
     end
   end
 

--- a/lib/field_struct/structs/strict.rb
+++ b/lib/field_struct/structs/strict.rb
@@ -11,6 +11,10 @@ module FieldStruct
       def field_struct_type
         :strict
       end
+
+      def mutable?
+        false
+      end
     end
 
     # @param [Hash] attributes

--- a/lib/field_struct/version.rb
+++ b/lib/field_struct/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FieldStruct
-  VERSION = '0.2.28'
+  VERSION = '0.2.29'
 end

--- a/spec/structs/flexible_spec.rb
+++ b/spec/structs/flexible_spec.rb
@@ -54,7 +54,7 @@ end
 
 RSpec.describe FieldStruct::FlexibleExamples::User do
   describe 'class' do
-    it "responds to .mutable?" do
+    it 'responds to .mutable?' do
       expect(described_class).to respond_to :mutable?
       expect(described_class.mutable?).to be(false)
     end

--- a/spec/structs/flexible_spec.rb
+++ b/spec/structs/flexible_spec.rb
@@ -54,6 +54,10 @@ end
 
 RSpec.describe FieldStruct::FlexibleExamples::User do
   describe 'class' do
+    it "responds to .mutable?" do
+      expect(described_class).to respond_to :mutable?
+      expect(described_class.mutable?).to be(false)
+    end
     it { expect(described_class.model_name).to be_a ActiveModel::Name }
     it { expect(described_class.extras).to eq :raise }
     context '.metadata' do

--- a/spec/structs/mutable_spec.rb
+++ b/spec/structs/mutable_spec.rb
@@ -51,6 +51,10 @@ end
 
 RSpec.describe FieldStruct::MutableExamples::User do
   describe 'class' do
+    it "responds to .mutable?" do
+      expect(described_class).to respond_to :mutable?
+      expect(described_class.mutable?).to be(true)
+    end
     it { expect(described_class.model_name).to be_a ActiveModel::Name }
     it { expect(described_class.extras).to eq :raise }
     context '.metadata' do

--- a/spec/structs/mutable_spec.rb
+++ b/spec/structs/mutable_spec.rb
@@ -51,7 +51,7 @@ end
 
 RSpec.describe FieldStruct::MutableExamples::User do
   describe 'class' do
-    it "responds to .mutable?" do
+    it 'responds to .mutable?' do
       expect(described_class).to respond_to :mutable?
       expect(described_class.mutable?).to be(true)
     end

--- a/spec/structs/strict_spec.rb
+++ b/spec/structs/strict_spec.rb
@@ -49,6 +49,10 @@ end
 
 RSpec.describe FieldStruct::StrictExamples::User do
   describe 'class' do
+    it "responds to .mutable?" do
+      expect(described_class).to respond_to :mutable?
+      expect(described_class.mutable?).to be(false)
+    end
     it { expect(described_class.model_name).to be_a ActiveModel::Name }
     it { expect(described_class.extras).to eq :raise }
     context '.metadata' do

--- a/spec/structs/strict_spec.rb
+++ b/spec/structs/strict_spec.rb
@@ -49,7 +49,7 @@ end
 
 RSpec.describe FieldStruct::StrictExamples::User do
   describe 'class' do
-    it "responds to .mutable?" do
+    it 'responds to .mutable?' do
       expect(described_class).to respond_to :mutable?
       expect(described_class.mutable?).to be(false)
     end


### PR DESCRIPTION
https://upbd.atlassian.net/browse/MPI-757

In ActiveModel 8.1, Attribute now calls `mutable?` on the model class, which `field_struct` doesn't implement.

Adding support for `mutable?`.